### PR TITLE
Refactor Perl control flow and naming compliance

### DIFF
--- a/lib/Engine/Fuzzer.pm
+++ b/lib/Engine/Fuzzer.pm
@@ -7,23 +7,23 @@ package Engine::Fuzzer {
     sub new {
         my ($self, $timeout, $headers, $skipssl, $proxy) = @_;
 
-        my $userAgent = Mojo::UserAgent -> new() -> request_timeout($timeout) -> insecure($skipssl);
+        my $user_agent = Mojo::UserAgent -> new() -> request_timeout($timeout) -> insecure($skipssl);
 
         if ($proxy) {
-            $userAgent -> proxy -> http($proxy);
-            $userAgent -> proxy -> https($proxy);
+            $user_agent -> proxy -> http($proxy);
+            $user_agent -> proxy -> https($proxy);
         }
 
         bless {
-            useragent => $userAgent,
-            headers   => $headers
+            user_agent => $user_agent,
+            headers    => $headers
         }, $self;
     }
 
     sub request {
         my ($self, $method, $agent, $endpoint, $payload, $accept) = @_;
 
-        my $request = $self -> {useragent} -> build_tx (
+        my $request = $self -> {user_agent} -> build_tx (
             $method => $endpoint => {
                 "User-Agent" => $agent,
                 %{$self -> {headers}}
@@ -31,7 +31,7 @@ package Engine::Fuzzer {
         );
 
         try {
-            my $response  = $self -> {useragent} -> start($request) -> result();
+            my $response = $self -> {user_agent} -> start($request) -> result();
 
             my $content_type = $response -> headers() -> content_type();
 

--- a/lib/Engine/Orchestrator.pm
+++ b/lib/Engine/Orchestrator.pm
@@ -11,14 +11,18 @@ package Engine::Orchestrator  {
         my ($list, $number) = @_;
 
         for (1 .. $number) {
-            return unless (@{$list} > 0);
+            if (@{$list} <= 0) {
+                return;
+            }
 
             if (eof($list -> [0])) {
                 close shift @{$list};
 
-                (@{$list} > 0) || $wordlist_queue -> end();
+                if (@{$list} <= 0) {
+                    $wordlist_queue -> end();
+                }
 
-                next
+                next;
             }
 
             my $filehandle = $list -> [0];
@@ -33,7 +37,9 @@ package Engine::Orchestrator  {
         my (@targets) = @_;
 
         for my $target (@targets) {
-            $target .= "/" unless $target =~ /\/$/x;
+            if ($target !~ /\/$/x) {
+                $target .= "/";
+            }
 
             lock(@targets_queue);
 

--- a/lib/Functions/Helper.pm
+++ b/lib/Functions/Helper.pm
@@ -12,7 +12,7 @@ package Functions::Helper {
             \r\t-A, --accept      Define a custom 'Accept' header
             \r\t-T, --tasks       The number of threads to run concurrently, default is 30
             \r\t-H, --header      Define a custom header (header=value)
-            \r\t-m, --method      Define HTTP methods to use during fuzzing, separeted by \",\"
+            \r\t-m, --method      Define HTTP methods to use during fuzzing, separated by \",\"
             \r\t-u, --url         Define a target
             \r\t-w, --wordlist    Define wordlist of paths
             \r\t-d, --delay       Define seconds of delay between requests
@@ -20,11 +20,11 @@ package Functions::Helper {
             \r\t-r, --return      Set a filter based on HTTP Response Code
             \r\t-e, --exclude     Exclude a specific result based on HTTP Response Code
             \r\t-t, --timeout     Define the timeout, default is 10s
-            \r\t-p, --payload     Send a custom data
+            \r\t-p, --payload     Send custom payload data
             \r\t-j, --json        Display the results in JSON line format (one json object per line)
             \r\t-W, --workflow    Pass a YML file with a fuzzing workflow
             \r\t-S, --skip-ssl    Ignore SSL verification
-            \r\t-l, --length      Filter by the length of content response 
+            \r\t-l, --length      Filter by the length of content response
             \r\t-c, --content     Filter by string based on the content response
             \r\t-C, --filter-content-type  Filter by Content-Type header values
             \r\t-P, --proxy       Send all requests through a proxy

--- a/lib/Functions/Parser.pm
+++ b/lib/Functions/Parser.pm
@@ -7,11 +7,11 @@ package Functions::Parser {
         my ($self, $workflow) = @_;
 
         if ($workflow) {
-			my $yamlfile = YAML::Tiny -> read($workflow);
- 	        my $rules = $yamlfile -> [0] -> {rules};
+            my $yaml_file = YAML::Tiny -> read($workflow);
+            my $workflow_rules = $yaml_file -> [0] -> {rules};
 
-			return $rules;
-		}
+            return $workflow_rules;
+        }
 	}
 }
 

--- a/nozaki.pl
+++ b/nozaki.pl
@@ -1,3 +1,4 @@
+#!/usr/bin/env perl
 use 5.030;
 use strict;
 use threads;

--- a/nozaki.pl
+++ b/nozaki.pl
@@ -1,5 +1,3 @@
-#!/usr/bin/env perl
-
 use 5.030;
 use strict;
 use threads;
@@ -12,9 +10,9 @@ use Engine::Orchestrator;
 use Getopt::Long qw(:config no_ignore_case);
 
 sub main {
-    my ($workflow, @targets);
+    my ($workflow_path, @targets);
 
-    my %options = (
+    my %fuzzer_options = (
         accept   => "*/*",
         wordlist => "wordlists/default.txt",
         method   => "GET,POST,PUT,DELETE,HEAD,OPTIONS,PATCH,PUSH",
@@ -26,40 +24,52 @@ sub main {
     );
 
     Getopt::Long::GetOptions (
-        "A|accept=s"              => \$options{accept},
-        "a|agent=s"               => \$options{agent},
-        "c|content=s"             => \$options{content},
-        "d|delay=i"               => \$options{delay},
-        "e|exclude=s"             => \$options{exclude},
-        "H|header=s%"             => \$options{headers},
-        "w|wordlist=s"            => \$options{wordlist},
-        "W|workflow=s"            => \$workflow,
-        "m|method=s"              => \$options{method},
-        "r|return=s"              => \$options{return},
-        "p|payload=s"             => \$options{payload},
-        "j|json"                  => \$options{json},
-        "S|skip-ssl"              => \$options{skipssl},
-        "T|tasks=i"               => \$options{tasks},
-        "t|timeout=i"             => \$options{timeout},
+        "A|accept=s"              => \$fuzzer_options{accept},
+        "a|agent=s"               => \$fuzzer_options{agent},
+        "c|content=s"             => \$fuzzer_options{content},
+        "d|delay=i"               => \$fuzzer_options{delay},
+        "e|exclude=s"             => \$fuzzer_options{exclude},
+        "H|header=s%"             => \$fuzzer_options{headers},
+        "w|wordlist=s"            => \$fuzzer_options{wordlist},
+        "W|workflow=s"            => \$workflow_path,
+        "m|method=s"              => \$fuzzer_options{method},
+        "r|return=s"              => \$fuzzer_options{return},
+        "p|payload=s"             => \$fuzzer_options{payload},
+        "j|json"                  => \$fuzzer_options{json},
+        "S|skip-ssl"              => \$fuzzer_options{skipssl},
+        "T|tasks=i"               => \$fuzzer_options{tasks},
+        "t|timeout=i"             => \$fuzzer_options{timeout},
         "u|url=s@"                => \@targets,
-        "l|length=s"              => \$options{length},
-        "C|filter-content-type=s" => \$options{content_type},
-        "P|proxy=s"               => \$options{proxy}
+        "l|length=s"              => \$fuzzer_options{length},
+        "C|filter-content-type=s" => \$fuzzer_options{content_type},
+        "P|proxy=s"               => \$fuzzer_options{proxy}
     );
 
-    return Functions::Helper -> new() unless @targets;
+    if (!@targets) {
+        return Functions::Helper -> new();
+    }
 
-    if ($workflow) {
-        my $rules = Functions::Parser -> new($workflow);
+    if ($workflow_path) {
+        my $rules = Functions::Parser -> new($workflow_path);
 
         for my $rule (@$rules) {
-            my %new_options = %options;
+            my %workflow_options = %fuzzer_options;
 
             Engine::Orchestrator::add_target(@targets);
 
-            map { $new_options{$_} = $rule -> {$_} || 1 } keys %{$rule};
+            for my $rule_key (keys %{$rule}) {
+                my $rule_value = $rule -> {$rule_key};
 
-            Engine::Orchestrator -> run_fuzzer(%new_options);
+                if ($rule_value) {
+                    $workflow_options{$rule_key} = $rule_value;
+                }
+
+                if (!$rule_value) {
+                    $workflow_options{$rule_key} = 1;
+                }
+            }
+
+            Engine::Orchestrator -> run_fuzzer(%workflow_options);
         }
 
         return 0;
@@ -67,7 +77,9 @@ sub main {
 
     Engine::Orchestrator::add_target(@targets);
 
-    return Engine::Orchestrator -> run_fuzzer(%options);
+    return Engine::Orchestrator -> run_fuzzer(%fuzzer_options);
 }
 
-exit main() unless caller;
+if (!caller) {
+    exit main();
+}


### PR DESCRIPTION
### Motivation
- Remove post-conditional and ambiguous control flow and make conditional logic explicit across the codebase for better readability and rule compliance. 
- Improve variable and field naming to make intent clearer in the fuzzer components and to avoid confusing identifiers. 
- Fix small text and formatting inconsistencies in help output and parsing to improve usability.

### Description
- Replace post-conditions and implicit control usage in `lib/Engine/Orchestrator.pm` by adding explicit `if` checks and early returns, and normalize targets to always end with a trailing slash using explicit conditional logic. 
- Rename and clarify variables in `lib/Engine/FuzzerThread.pm`, introduce `length_filter` and `length_comparator` with explicit comparator handling blocks, replace the JSON encoder variable with `json_encoder`, and replace `found` with `was_found`. 
- Rename the user agent and storage keys in `lib/Engine/Fuzzer.pm` to `user_agent`/`user_agent` and update all accessors accordingly. 
- Improve parsing variable names in `lib/Functions/Parser.pm` and return the parsed workflow rules using a clearer identifier, and clean up help text phrasing in `lib/Functions/Helper.pm`. 
- Refactor CLI option handling in `nozaki.pl` by renaming `workflow` to `workflow_path` and `options` to `fuzzer_options`, convert post-conditional and `map`-based option mergers into explicit loops that set workflow-specific options, and make the `exit main()` invocation explicit when the script is not loaded as a module.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972901b3bfc832baafd05acdb815621)