### PR TITLE
Use three-argument open when loading wordlists in Engine::Orchestrator

### DIFF
--- a/lib/Engine/Orchestrator.pm
+++ b/lib/Engine/Orchestrator.pm
@@ -65,7 +65,7 @@ package Engine::Orchestrator  {
         my ($self, $target, %options) = @_;
 
         my @current = map {
-            open(my $filehandle, "<$_") || die "$0: Can't open $_: $!";
+            open(my $filehandle, "<", $_) || die "$0: Can't open $_: $!";
 
             $filehandle
         } glob($options{wordlist});


### PR DESCRIPTION
### Motivation
- Replace the two-argument `open` usage flagged by PBP with a safer three-argument form when opening wordlist files in `lib/Engine/Orchestrator.pm` to avoid potential security and parsing issues.

### Description
- Change `open(my $filehandle, "<$_")` to `open(my $filehandle, "<", $_)` in `lib/Engine/Orchestrator.pm` so wordlist files are opened using the three-argument `open`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972cabf1350832b8e4b81539d989b23)