### PR TITLE
Use q{} for empty strings

### DIFF
--- a/lib/Engine/Fuzzer.pm
+++ b/lib/Engine/Fuzzer.pm
@@ -41,7 +41,7 @@ package Engine::Fuzzer {
         my $request = $self -> {user_agent} -> build_tx(
             $options{method} => $options{endpoint} => {
                 %headers
-            } => $options{payload} || ""
+            } => $options{payload} || q{}
         );
 
         my $result = try {
@@ -50,7 +50,7 @@ package Engine::Fuzzer {
             my $content_type = $response -> headers() -> content_type();
 
             if (!$content_type) {
-                $content_type = "";
+                $content_type = q{};
             }
 
             my $response_data = {

--- a/lib/Engine/FuzzerThread.pm
+++ b/lib/Engine/FuzzerThread.pm
@@ -12,8 +12,8 @@ package Engine::FuzzerThread {
         my ($self, %options) = @_;
 
         my @verbs         = split /,/x, $options{methods};
-        my @valid_codes   = split /,/x, $options{return} || "";
-        my @invalid_codes = split /,/x, $options{exclude} || "";
+        my @valid_codes   = split /,/x, $options{return} || q{};
+        my @invalid_codes = split /,/x, $options{exclude} || q{};
 
         my %valid_code_lookup = ();
         my %invalid_code_lookup = ();
@@ -129,7 +129,7 @@ package Engine::FuzzerThread {
 
                     if (!$options{content}
                         || $result -> {Content} =~ m/$options{content}/x) {
-                        my $message = "";
+                        my $message = q{};
 
                         if ($options{json}) {
                             $message = $json_encoder -> encode($result);

--- a/lib/Functions/ContentTypeFilter.pm
+++ b/lib/Functions/ContentTypeFilter.pm
@@ -27,7 +27,7 @@ package Functions::ContentTypeFilter {
                 next;
             }
 
-            if ($filter eq "") {
+            if ($filter eq q{}) {
                 next;
             }
 

--- a/t/filter-content-type.t
+++ b/t/filter-content-type.t
@@ -25,7 +25,7 @@ ok(
 );
 
 ok(
-    !Functions::ContentTypeFilter::content_type_matches("", \@filters),
+    !Functions::ContentTypeFilter::content_type_matches(q{}, \@filters),
     "does not match empty content type"
 );
 
@@ -34,7 +34,7 @@ ok(
     "does not match when filters are missing"
 );
 
-my @filters_with_empty = ("", "application/xml");
+my @filters_with_empty = (q{}, "application/xml");
 
 ok(
     Functions::ContentTypeFilter::content_type_matches("application/xml; charset=UTF-8", \@filters_with_empty),


### PR DESCRIPTION
### Motivation
- Fix Perl::Critic / PBP style warnings about quoted empty strings by replacing `""` with `q{}` for empty strings.

### Description
- Replace empty string literals with `q{}` in `t/filter-content-type.t` to update tests referencing empty content values.
- Replace `""` checks with `q{}` in `lib/Functions/ContentTypeFilter.pm` to avoid quoted-empty-string style violations when filtering.
- Use `q{}` for default/empty payloads, content-type defaults, and default message initialization in `lib/Engine/Fuzzer.pm` and `lib/Engine/FuzzerThread.pm`.
- These edits are stylistic and do not change program logic or external behavior.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697346cd9e48832ba6ef2b091113a249)