### PR TITLE
Fix literal string interpolation warnings

### DIFF
--- a/lib/Engine/Fuzzer.pm
+++ b/lib/Engine/Fuzzer.pm
@@ -4,7 +4,7 @@ package Engine::Fuzzer {
     use Try::Tiny;
     use Mojo::UserAgent;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, %options) = @_;
@@ -30,7 +30,7 @@ package Engine::Fuzzer {
         my ($self, %options) = @_;
 
         my %headers = (
-            "User-Agent" => $options{agent},
+            'User-Agent' => $options{agent},
             %{$self -> {headers}}
         );
 
@@ -54,13 +54,13 @@ package Engine::Fuzzer {
             }
 
             my $response_data = {
-                "Method"   => $options{method},
-                "URL"      => $options{endpoint},
-                "Code"     => $response -> code(),
-                "Response" => $response -> message(),
-                "Content"  => $response -> body(),
-                "Length"   => $response -> headers() -> content_length() || "0",
-                "ContentType" => $content_type
+                'Method'      => $options{method},
+                'URL'         => $options{endpoint},
+                'Code'        => $response -> code(),
+                'Response'    => $response -> message(),
+                'Content'     => $response -> body(),
+                'Length'      => $response -> headers() -> content_length() || '0',
+                'ContentType' => $content_type
             };
 
             return $response_data;

--- a/lib/Engine/FuzzerThread.pm
+++ b/lib/Engine/FuzzerThread.pm
@@ -6,7 +6,7 @@ package Engine::FuzzerThread {
     use Engine::Fuzzer;
     use Functions::ContentTypeFilter;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, %options) = @_;
@@ -52,27 +52,27 @@ package Engine::FuzzerThread {
             ($comparator_symbol, $options{length_filter})
                 = $options{length_filter} =~ /([>=<]{0,2})(\d+)/xms;
 
-            if ($comparator_symbol eq ">=") {
+            if ($comparator_symbol eq '>=') {
                 $length_comparator = sub { $_[0] >= $options{length_filter} };
             }
 
-            if ($comparator_symbol eq "<=") {
+            if ($comparator_symbol eq '<=') {
                 $length_comparator = sub { $_[0] <= $options{length_filter} };
             }
 
-            if ($comparator_symbol eq "<>") {
+            if ($comparator_symbol eq '<>') {
                 $length_comparator = sub { $_[0] != $options{length_filter} };
             }
 
-            if ($comparator_symbol eq ">") {
+            if ($comparator_symbol eq '>') {
                 $length_comparator = sub { $_[0] > $options{length_filter} };
             }
 
-            if ($comparator_symbol eq "<") {
+            if ($comparator_symbol eq '<') {
                 $length_comparator = sub { $_[0] < $options{length_filter} };
             }
 
-            if (!$comparator_symbol || $comparator_symbol eq "=") {
+            if (!$comparator_symbol || $comparator_symbol eq '=') {
                 $length_comparator = sub { $_[0] == $options{length_filter} };
             }
         }
@@ -137,11 +137,11 @@ package Engine::FuzzerThread {
 
                         if (!$options{json}) {
                             $message = sprintf(
-                                "Code: %d | URL: %s | Method: %s | Response: %s | Length: %s",
+                                'Code: %d | URL: %s | Method: %s | Response: %s | Length: %s',
                                 $status,
                                 $result -> {URL},
                                 $result -> {Method},
-                                $result -> {Response} || "?",
+                                $result -> {Response} || '?',
                                 $result -> {Length}
                             );
                         }

--- a/lib/Engine/Orchestrator.pm
+++ b/lib/Engine/Orchestrator.pm
@@ -5,7 +5,7 @@ package Engine::Orchestrator  {
     use Carp qw(croak);
     use Engine::FuzzerThread;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     my $wordlist_queue;
     my @targets_queue :shared;
@@ -32,7 +32,7 @@ package Engine::Orchestrator  {
 
         for my $target (@targets) {
             if ($target !~ /\/$/xms) {
-                $target .= "/";
+                $target .= '/';
             }
 
             lock(@targets_queue);
@@ -66,7 +66,7 @@ package Engine::Orchestrator  {
         my @wordlists = split /,/xms, $options{wordlist};
 
         for my $wordlist (@wordlists) {
-            open(my $filehandle, "<", $wordlist)
+            open(my $filehandle, '<', $wordlist)
                 || croak "$0: Can't open $wordlist: $!";
 
             my @lines = <$filehandle>;

--- a/lib/Functions/ContentTypeFilter.pm
+++ b/lib/Functions/ContentTypeFilter.pm
@@ -2,7 +2,7 @@ package Functions::ContentTypeFilter {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub content_type_matches {
         my ($content_type, $filters) = @_;

--- a/lib/Functions/Helper.pm
+++ b/lib/Functions/Helper.pm
@@ -2,7 +2,7 @@ package Functions::Helper {
 	use strict;
 	use warnings;
 
-	our $VERSION = "0.3.1";
+	our $VERSION = '0.3.1';
 
 	sub new {
         print "

--- a/lib/Functions/Parser.pm
+++ b/lib/Functions/Parser.pm
@@ -3,7 +3,7 @@ package Functions::Parser {
 	use warnings;
     use YAML::Tiny;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
 	sub new {
         my ($self, $workflow) = @_;

--- a/lib/Functions/Plugins.pm
+++ b/lib/Functions/Plugins.pm
@@ -2,7 +2,7 @@ package Functions::Plugins {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self) = @_;

--- a/lib/Plugins/Encode/Base64.pm
+++ b/lib/Plugins/Encode/Base64.pm
@@ -2,7 +2,7 @@ package Plugins::Encode::Base64 {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, @params) = @_;

--- a/lib/Plugins/Seeds/BurpSuite.pm
+++ b/lib/Plugins/Seeds/BurpSuite.pm
@@ -2,7 +2,7 @@ package Plugins::Seeds::BurpSuite {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, @params) = @_;

--- a/lib/Plugins/Seeds/OpenAPI.pm
+++ b/lib/Plugins/Seeds/OpenAPI.pm
@@ -2,7 +2,7 @@ package Plugins::Seeds::OpenAPI {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, @params) = @_;

--- a/lib/Plugins/Seeds/Passive_Collect.pm
+++ b/lib/Plugins/Seeds/Passive_Collect.pm
@@ -2,7 +2,7 @@ package Plugins::Seeds::Passive_Collect {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, @params) = @_;

--- a/lib/Plugins/Seeds/Robots.pm
+++ b/lib/Plugins/Seeds/Robots.pm
@@ -2,7 +2,7 @@ package Plugins::Seeds::Robots {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, @params) = @_;

--- a/lib/Plugins/Seeds/Scraping.pm
+++ b/lib/Plugins/Seeds/Scraping.pm
@@ -2,7 +2,7 @@ package Plugins::Seeds::Scraping {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, @params) = @_;

--- a/lib/Plugins/Seeds/Sitemap.pm
+++ b/lib/Plugins/Seeds/Sitemap.pm
@@ -2,7 +2,7 @@ package Plugins::Seeds::Sitemap {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, @params) = @_;

--- a/lib/Plugins/Seeds/Swagger.pm
+++ b/lib/Plugins/Seeds/Swagger.pm
@@ -2,7 +2,7 @@ package Plugins::Seeds::Swagger {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, @params) = @_;

--- a/lib/Plugins/Seeds/WayBackUrls.pm
+++ b/lib/Plugins/Seeds/WayBackUrls.pm
@@ -2,7 +2,7 @@ package Plugins::Seeds::WayBackUrls {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, @params) = @_;

--- a/lib/Plugins/Seeds/ZAP.pm
+++ b/lib/Plugins/Seeds/ZAP.pm
@@ -2,7 +2,7 @@ package Plugins::Seeds::ZAP {
     use strict;
     use warnings;
 
-    our $VERSION = "0.3.1";
+    our $VERSION = '0.3.1';
 
     sub new {
         my ($self, @params) = @_;

--- a/nozaki.pl
+++ b/nozaki.pl
@@ -4,48 +4,48 @@ use strict;
 use threads;
 use warnings;
 use Thread::Queue;
-use Find::Lib "./lib";
+use Find::Lib './lib';
 use Functions::Helper;
 use Functions::Parser;
 use Engine::Orchestrator;
 use Getopt::Long qw(:config no_ignore_case);
 
-our $VERSION = "0.3.1";
+our $VERSION = '0.3.1';
 
 sub main {
     my ($workflow_path, @targets);
 
     my %fuzzer_options = (
-        accept   => "*/*",
-        wordlist => "wordlists/default.txt",
-        method   => "GET,POST,PUT,DELETE,HEAD,OPTIONS,PATCH,PUSH",
+        accept   => '*/*',
+        wordlist => 'wordlists/default.txt',
+        method   => 'GET,POST,PUT,DELETE,HEAD,OPTIONS,PATCH,PUSH',
         headers  => {},
         timeout  => 10,
-        agent    => "Nozaki / 0.3.1",
+        agent    => 'Nozaki / 0.3.1',
         tasks    => 35,
         delay    => 0
     );
 
     Getopt::Long::GetOptions (
-        "A|accept=s"              => \$fuzzer_options{accept},
-        "a|agent=s"               => \$fuzzer_options{agent},
-        "c|content=s"             => \$fuzzer_options{content},
-        "d|delay=i"               => \$fuzzer_options{delay},
-        "e|exclude=s"             => \$fuzzer_options{exclude},
-        "H|header=s%"             => \$fuzzer_options{headers},
-        "w|wordlist=s"            => \$fuzzer_options{wordlist},
-        "W|workflow=s"            => \$workflow_path,
-        "m|method=s"              => \$fuzzer_options{method},
-        "r|return=s"              => \$fuzzer_options{return},
-        "p|payload=s"             => \$fuzzer_options{payload},
-        "j|json"                  => \$fuzzer_options{json},
-        "S|skip-ssl"              => \$fuzzer_options{skipssl},
-        "T|tasks=i"               => \$fuzzer_options{tasks},
-        "t|timeout=i"             => \$fuzzer_options{timeout},
-        "u|url=s@"                => \@targets,
-        "l|length=s"              => \$fuzzer_options{length},
-        "C|filter-content-type=s" => \$fuzzer_options{content_type},
-        "P|proxy=s"               => \$fuzzer_options{proxy}
+        'A|accept=s'              => \$fuzzer_options{accept},
+        'a|agent=s'               => \$fuzzer_options{agent},
+        'c|content=s'             => \$fuzzer_options{content},
+        'd|delay=i'               => \$fuzzer_options{delay},
+        'e|exclude=s'             => \$fuzzer_options{exclude},
+        'H|header=s%'             => \$fuzzer_options{headers},
+        'w|wordlist=s'            => \$fuzzer_options{wordlist},
+        'W|workflow=s'            => \$workflow_path,
+        'm|method=s'              => \$fuzzer_options{method},
+        'r|return=s'              => \$fuzzer_options{return},
+        'p|payload=s'             => \$fuzzer_options{payload},
+        'j|json'                  => \$fuzzer_options{json},
+        'S|skip-ssl'              => \$fuzzer_options{skipssl},
+        'T|tasks=i'               => \$fuzzer_options{tasks},
+        't|timeout=i'             => \$fuzzer_options{timeout},
+        'u|url=s@'                => \@targets,
+        'l|length=s'              => \$fuzzer_options{length},
+        'C|filter-content-type=s' => \$fuzzer_options{content_type},
+        'P|proxy=s'               => \$fuzzer_options{proxy}
     );
 
     if (!@targets) {

--- a/t/filter-content-type.t
+++ b/t/filter-content-type.t
@@ -5,40 +5,43 @@ use warnings;
 use Test::More tests => 6;
 use Functions::ContentTypeFilter;
 
-our $VERSION = "0.3.1";
+our $VERSION = '0.3.1';
 
-my @filters = ("application/json", "text/html");
+my @filters = ('application/json', 'text/html');
 
 ok(
-    Functions::ContentTypeFilter::content_type_matches("application/json; charset=utf-8", \@filters),
-    "matches json content type with charset"
+    Functions::ContentTypeFilter::content_type_matches('application/json; charset=utf-8', \@filters),
+    'matches json content type with charset'
 );
 
 ok(
-    Functions::ContentTypeFilter::content_type_matches("TEXT/HTML", \@filters),
-    "matches content type regardless of case"
+    Functions::ContentTypeFilter::content_type_matches('TEXT/HTML', \@filters),
+    'matches content type regardless of case'
 );
 
 ok(
-    !Functions::ContentTypeFilter::content_type_matches("application/xml", \@filters),
-    "does not match when content type is not in filters"
+    !Functions::ContentTypeFilter::content_type_matches('application/xml', \@filters),
+    'does not match when content type is not in filters'
 );
 
 ok(
     !Functions::ContentTypeFilter::content_type_matches(q{}, \@filters),
-    "does not match empty content type"
+    'does not match empty content type'
 );
 
 ok(
-    !Functions::ContentTypeFilter::content_type_matches("application/json", []),
-    "does not match when filters are missing"
+    !Functions::ContentTypeFilter::content_type_matches('application/json', []),
+    'does not match when filters are missing'
 );
 
-my @filters_with_empty = (q{}, "application/xml");
+my @filters_with_empty = (q{}, 'application/xml');
 
 ok(
-    Functions::ContentTypeFilter::content_type_matches("application/xml; charset=UTF-8", \@filters_with_empty),
-    "matches when one valid filter is present"
+    Functions::ContentTypeFilter::content_type_matches(
+        'application/xml; charset=UTF-8',
+        \@filters_with_empty
+    ),
+    'matches when one valid filter is present'
 );
 
 1;


### PR DESCRIPTION
### Motivation
- Eliminate a large number of Perl warnings about useless interpolation of literal strings by converting unnecessary double-quoted literals to single-quoted literals across the codebase.
- Ensure consistent non-interpolated version strings and option/metadata keys to reduce noise from the linter while preserving runtime behavior.
- Make small style normalizations (e.g. open mode and path concatenation) to use consistent quoting.

### Description
- Replaced double-quoted literal strings with single-quoted literals in the main entrypoint (`nozaki.pl`) for CLI defaults and `Getopt::Long` option specifications to avoid interpolation warnings while keeping behavior unchanged.
- Updated `Engine::Fuzzer`, `Engine::FuzzerThread`, and `Engine::Orchestrator` to use single-quoted hash keys and comparator literals and to normalize file open mode and path concatenation quoting without changing logic.
- Standardized `our $VERSION` declarations and similar module literals to single-quoted strings across many modules and plugin seed files.
- Adjusted test literals in `t/filter-content-type.t` to single-quoted strings so the test suite is free of the useless-interpolation warnings.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973657dcb5c832bb4b95bc2cbd351e8)