### PR TITLE
Normalize noisy string quoting in Engine modules

### DIFF
--- a/lib/Engine/FuzzerThread.pm
+++ b/lib/Engine/FuzzerThread.pm
@@ -72,7 +72,7 @@ package Engine::FuzzerThread {
                 $length_comparator = sub { $_[0] < $options{length_filter} };
             }
 
-            if (!$comparator_symbol || $comparator_symbol eq '=') {
+            if (!$comparator_symbol || $comparator_symbol eq q{=}) {
                 $length_comparator = sub { $_[0] == $options{length_filter} };
             }
         }
@@ -141,7 +141,7 @@ package Engine::FuzzerThread {
                                 $status,
                                 $result -> {URL},
                                 $result -> {Method},
-                                $result -> {Response} || '?',
+                                $result -> {Response} || q{?},
                                 $result -> {Length}
                             );
                         }

--- a/lib/Engine/Orchestrator.pm
+++ b/lib/Engine/Orchestrator.pm
@@ -32,7 +32,7 @@ package Engine::Orchestrator  {
 
         for my $target (@targets) {
             if ($target !~ /\/$/xms) {
-                $target .= '/';
+                $target .= q{/};
             }
 
             lock(@targets_queue);


### PR DESCRIPTION
### Motivation
- Address Perl::Critic / Perl Best Practices warnings about noisy single-character string literals by using `q{}` quoting in the fuzzer components to improve style consistency without changing behavior.

### Description
- Replace target suffix literal `"/"` with `q{/}` in `lib/Engine/Orchestrator.pm` to satisfy noisy-string guidance.
- Replace comparator equality check literal `"="` with `q{=}` in `lib/Engine/FuzzerThread.pm` to avoid noisy quoting.
- Replace response-fallback literal `"?"` with `q{?}` in `lib/Engine/FuzzerThread.pm` for consistent noisy-string handling.
- These changes are purely stylistic and do not alter runtime logic or interfaces.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697369714360832bbacabcc4b41560da)