### PR TITLE
Refine help text assembly into an array and join at print time

### DIFF
--- a/lib/Functions/Helper.pm
+++ b/lib/Functions/Helper.pm
@@ -1,39 +1,42 @@
 package Functions::Helper {
-	use strict;
-	use warnings;
+    use strict;
+    use warnings;
 
-	our $VERSION = '0.3.1';
+    our $VERSION = '0.3.1';
 
-	sub new {
-        print "
-            \rNozaki v0.3.1
-            \rCore Commands
-            \r==============
-            \r\tCommand           Description
-            \r\t-------           -----------
-            \r\t-A, --accept      Define a custom 'Accept' header
-            \r\t-T, --tasks       The number of threads to run concurrently, default is 30
-            \r\t-H, --header      Define a custom header (header=value)
-            \r\t-m, --method      Define HTTP methods to use during fuzzing, separated by \",\"
-            \r\t-u, --url         Define a target
-            \r\t-w, --wordlist    Define wordlist of paths
-            \r\t-d, --delay       Define seconds of delay between requests
-            \r\t-a, --agent       Define a custom User Agent
-            \r\t-r, --return      Set a filter based on HTTP Response Code
-            \r\t-e, --exclude     Exclude a specific result based on HTTP Response Code
-            \r\t-t, --timeout     Define the timeout, default is 10s
-            \r\t-p, --payload     Send custom payload data
-            \r\t-j, --json        Display the results in JSON line format (one json object per line)
-            \r\t-W, --workflow    Pass a YML file with a fuzzing workflow
-            \r\t-S, --skip-ssl    Ignore SSL verification
-            \r\t-l, --length      Filter by the length of content response
-            \r\t-c, --content     Filter by string based on the content response
-            \r\t-C, --filter-content-type  Filter by Content-Type header values
-            \r\t-P, --proxy       Send all requests through a proxy
-            \r\t-h, --help        See this screen\n\n";
+    sub new {
+        my @help_lines = (
+            "\rNozaki v0.3.1",
+            "\rCore Commands",
+            "\r==============",
+            "\r\tCommand           Description",
+            "\r\t-------           -----------",
+            "\r\t-A, --accept      Define a custom 'Accept' header",
+            "\r\t-T, --tasks       The number of threads to run concurrently, default is 30",
+            "\r\t-H, --header      Define a custom header (header=value)",
+            "\r\t-m, --method      Define HTTP methods to use during fuzzing, separated by \",\"",
+            "\r\t-u, --url         Define a target",
+            "\r\t-w, --wordlist    Define wordlist of paths",
+            "\r\t-d, --delay       Define seconds of delay between requests",
+            "\r\t-a, --agent       Define a custom User Agent",
+            "\r\t-r, --return      Set a filter based on HTTP Response Code",
+            "\r\t-e, --exclude     Exclude a specific result based on HTTP Response Code",
+            "\r\t-t, --timeout     Define the timeout, default is 10s",
+            "\r\t-p, --payload     Send custom payload data",
+            "\r\t-j, --json        Display the results in JSON line format (one json object per line)",
+            "\r\t-W, --workflow    Pass a YML file with a fuzzing workflow",
+            "\r\t-S, --skip-ssl    Ignore SSL verification",
+            "\r\t-l, --length      Filter by the length of content response",
+            "\r\t-c, --content     Filter by string based on the content response",
+            "\r\t-C, --filter-content-type  Filter by Content-Type header values",
+            "\r\t-P, --proxy       Send all requests through a proxy",
+            "\r\t-h, --help        See this screen"
+        );
 
-		return 0;
-	}
+        print join("\n", @help_lines) . "\n\n";
+
+        return 0;
+    }
 }
 
 1;


### PR DESCRIPTION
### Motivation
- Remove a literal multi-line string with embedded line breaks in the help output to make the source easier to read and align with project style guidelines.

### Description
- Replace the embedded multi-line string in `lib/Functions/Helper.pm` with an array `@help_lines` and use `print join("\n", @help_lines) . "\n\n";` to assemble the help text at runtime.
- Normalize indentation to four spaces and keep `use strict;`, `use warnings;` and `our $VERSION` unchanged, preserving the existing `new` interface and its `return 0;` behavior.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69736acc3bc4832b960d83f46234d4a4)