### PR TITLE
Replace magic error variable with $OS_ERROR in Orchestrator

### DIFF
--- a/lib/Engine/Orchestrator.pm
+++ b/lib/Engine/Orchestrator.pm
@@ -68,12 +68,12 @@ package Engine::Orchestrator  {
 
         for my $wordlist (@wordlists) {
             open(my $filehandle, '<', $wordlist)
-                || croak "$PROGRAM_NAME: Can't open $wordlist: $!";
+                || croak "$PROGRAM_NAME: Can't open $wordlist: $OS_ERROR";
 
             my @lines = <$filehandle>;
             my $close_ok = close $filehandle;
             if (!$close_ok) {
-                croak "$PROGRAM_NAME: Can't close $wordlist: $!";
+                croak "$PROGRAM_NAME: Can't close $wordlist: $OS_ERROR";
             }
 
             chomp @lines;


### PR DESCRIPTION
### Motivation
- Fix PBP warning about interpolating the magic punctuation variable `$/!` by replacing uses in `lib/Engine/Orchestrator.pm` to use the `English`-provided `$OS_ERROR` for clearer, safer error messages.

### Description
- Replace interpolated `"$!"` occurrences in croak messages with `$OS_ERROR` in `threaded_fuzz` when opening and closing wordlist files, with no other behavioral changes.

### Testing
- No automated tests were run against this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697685becc24832b912430ecbe5491f7)