### PR TITLE
Use constant for concurrent tasks in Engine::Orchestrator

### DIFF
--- a/lib/Engine/Orchestrator.pm
+++ b/lib/Engine/Orchestrator.pm
@@ -5,6 +5,7 @@ package Engine::Orchestrator  {
     use Carp qw(croak);
     use English qw(-no_match_vars);
     use Engine::FuzzerThread;
+    use constant CONCURRENT_TASKS => 10;
 
     our $VERSION = '0.3.1';
 
@@ -82,7 +83,7 @@ package Engine::Orchestrator  {
 
         $wordlist_queue = Thread::Queue -> new();
 
-        my $concurrent_tasks = 10;
+        my $concurrent_tasks = CONCURRENT_TASKS;
 
         fill_queue(\@current, $concurrent_tasks * $options{tasks});
 


### PR DESCRIPTION
### Motivation
- Replace an unnamed numeric literal with a named constant to improve maintainability and satisfy the linter warning about literal values.

### Description
- Add `use constant CONCURRENT_TASKS => 10;` to `lib/Engine/Orchestrator.pm`.
- Replace the literal `10` with `my $concurrent_tasks = CONCURRENT_TASKS;` to size the worker queue.
- No functional behavior changes are intended by this refactor.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69768a95cdf4832baa344d9163943903)